### PR TITLE
update feb and mar 2024 change log

### DIFF
--- a/_sidebar.md
+++ b/_sidebar.md
@@ -11,3 +11,5 @@
   - [2023-11](docs/changelog/2023-11.md)
   - [2023-12](docs/changelog/2023-12.md)
   - [2024-01](docs/changelog/2024-01.md)
+  - [2024-02](docs/changelog/2024-02.md)
+  - [2024-03](docs/changelog/2024-03.md)

--- a/docs/changelog/2024-02.md
+++ b/docs/changelog/2024-02.md
@@ -1,0 +1,15 @@
+# Changelog
+
+Changelog for Release 2024-02
+
+## Bug Fixes
+
+*No bug fixes*
+
+## New Features
+
+*No new features*
+
+## Breaking Changes
+
+*No breaking changes*

--- a/docs/changelog/2024-03.md
+++ b/docs/changelog/2024-03.md
@@ -1,0 +1,15 @@
+# Changelog
+
+Changelog for Release 2024-03
+
+## Bug Fixes
+
+*No bug fixes*
+
+## New Features
+
+*No new features*
+
+## Breaking Changes
+
+*No breaking changes*


### PR DESCRIPTION
Backdated the feb 2024 change log for notices.
Added the tentative mar 2024 change log for notices, subject to further changes.